### PR TITLE
Retrieve API-key

### DIFF
--- a/pages/api/generate.js
+++ b/pages/api/generate.js
@@ -1,11 +1,10 @@
 import { Configuration, OpenAIApi } from "openai";
 
-const configuration = new Configuration({
-  apiKey: process.env.OPENAI_API_KEY,
-});
-const openai = new OpenAIApi(configuration);
-
 export default async function (req, res) {
+  let configuration = new Configuration({
+    apiKey: process.env.OPENAI_API_KEY,
+  });
+
   if (!configuration.apiKey) {
     const apiKey = req.body.technical["api-key"] || '';
     if (apiKey.trim().length === 0) {
@@ -16,8 +15,12 @@ export default async function (req, res) {
       });
       return;
     }
-    configuration.apiKey = apiKey;
+    configuration = new Configuration({
+      apiKey: apiKey,
+    });
   }
+
+  const openai = new OpenAIApi(configuration);
 
   const prompt = req.body.prompt || '';
   


### PR DESCRIPTION
The openai-api key will be read from the .env file. If no key is provided there, it will use the bot's api key.